### PR TITLE
Correctly reference the minified moment.js distribution

### DIFF
--- a/moment-import.html
+++ b/moment-import.html
@@ -1,1 +1,1 @@
-<script src='../moment/min/moment.js'></script>
+<script src='../moment/min/moment.min.js'></script>

--- a/moment-with-locales-import.html
+++ b/moment-with-locales-import.html
@@ -1,1 +1,1 @@
-<script src='../moment/min/moment-with-locales.js'></script>
+<script src='../moment/min/moment-with-locales.min.js'></script>


### PR DESCRIPTION
For `moment-with-locales-import.html` this is an (almost cosmetic) improvement, but for `moment-import.html` it is a required fix.

Tested with moment.js 2.11.2, the current latest version.
